### PR TITLE
Fix quote input calculation in multicall

### DIFF
--- a/contracts/WaveFrontMulticall.sol
+++ b/contracts/WaveFrontMulticall.sol
@@ -292,7 +292,7 @@ contract WaveFrontMulticall {
      * @param token The address of the WaveFrontToken (Token.sol).
      * @param tokenAmtOut The desired amount of token output (18 dec).
      * @param slippageTolerance The maximum allowed input slippage parameter (e.g., 10050 for 0.5% slippage). Used in calculation for `minTokenAmtOut`.
-     * @return qouteRawIn Required quote token input (raw). Note the typo in the variable name from the original code.
+     * @return quoteRawIn Required quote token input (raw).
      * @return slippage Calculated slippage percentage * 100 (scaled by 100). Based on original code's formula.
      * @return minTokenAmtOut Result of `tokenAmtOut * slippageTolerance / DIVISOR`. Note: Confusing name in this context.
      * @return autoMinTokenAmtOut Result of calculation involving `tokenAmtOut` and `slippage`. Note: Confusing name in this context, calculation seems related to adjusted token amount based on slippage.
@@ -302,7 +302,7 @@ contract WaveFrontMulticall {
         uint256 tokenAmtOut, 
         uint256 slippageTolerance
     ) external view returns (
-        uint256 qouteRawIn,
+        uint256 quoteRawIn,
         uint256 slippage,
         uint256 minTokenAmtOut,
         uint256 autoMinTokenAmtOut
@@ -313,7 +313,7 @@ contract WaveFrontMulticall {
         uint256 y0 = IToken(token).reserveTokenAmt();
 
         uint256 quoteWadIn = DIVISOR.mulDivDown(x0.mulDivDown(y0, y0 - tokenAmtOut) - x0, DIVISOR - FEE);
-        qouteRawIn = IToken(token).rawToWad(quoteWadIn);
+        quoteRawIn = IToken(token).wadToRaw(quoteWadIn);
         slippage = 100 * (PRECISION - (tokenAmtOut.mulDivDown(IToken(token).getMarketPrice(), quoteWadIn)));
         minTokenAmtOut = tokenAmtOut.mulDivDown(slippageTolerance, DIVISOR);
         autoMinTokenAmtOut = tokenAmtOut.mulDivDown((DIVISOR * PRECISION) - ((slippage + PRECISION) * 100), DIVISOR * PRECISION);

--- a/tests/test2.js
+++ b/tests/test2.js
@@ -341,7 +341,7 @@ describe("local: test2 18 decimals", function () {
     console.log("WFT0 out", divDec(ten));
     console.log("Slippage Tolerance", "3%");
     console.log();
-    console.log("WETH in", divDec(res.qouteRawIn));
+    console.log("WETH in", divDec(res.quoteRawIn));
     console.log("slippage", divDec(res.slippage));
     console.log("min WFT0 out", divDec(res.minTokenAmtOut));
     console.log("auto min WFT0 out", divDec(res.autoMinTokenAmtOut));

--- a/tests/test3.js
+++ b/tests/test3.js
@@ -393,7 +393,7 @@ describe("local: test3 6 decimals", function () {
     console.log("WFT0 out", divDec(ten18));
     console.log("Slippage Tolerance", "3%");
     console.log();
-    console.log("USDC in", divDec6(res.qouteRawIn));
+    console.log("USDC in", divDec6(res.quoteRawIn));
     console.log("slippage", divDec(res.slippage));
     console.log("min Token out", divDec(res.minTokenAmtOut));
     console.log("min Token out", divDec(res.autoMinTokenAmtOut));


### PR DESCRIPTION
## Summary
- correct quote input calculation in `WaveFrontMulticall.buyTokenOut`
- update tests to use `quoteRawIn`

## Testing
- `npx hardhat compile` *(fails: EHOSTUNREACH 172.24.0.3:8080)*